### PR TITLE
Fix nondescript error on file not found

### DIFF
--- a/support/oai_pmh.erl
+++ b/support/oai_pmh.erl
@@ -21,7 +21,7 @@
 
 %% @doc Send a notification for each record in a OAI-PMH XML file
 import_file(File, Context) ->
-    {Root, _} = xmerl_scan:file(File, [{space, normalize}]),
+    {Root, []} = xmerl_scan:file(File, [{space, normalize}]),
     Records = parse_records(Root),
     [z_notifier:notify({oai_pmh_import, R}, Context) || R <- Records].
 


### PR DESCRIPTION
Forcing a non-error pattern match makes any error on loading the file more descriptive:
```
** exception error: no match of right hand side value {error,enoent}
     in function  oai_pmh:import_file/2 (.../mod_ginger_oai_pmh/support/oai_pmh.erl, line 24)
```
instead of the current
```
** exception error: no function clause matching xmerl_xpath:node_type(error) (xmerl_xpath.erl, line 645)
     in function  xmerl_xpath:string/5 (xmerl_xpath.erl, line 147)
     in call from oai_pmh:import_file/2 (.../mod_ginger_oai_pmh/support/oai_pmh.erl, line 25)
```
