### PR TITLE
Add logging, http options, and sync notifications

### DIFF
--- a/support/oai_pmh.erl
+++ b/support/oai_pmh.erl
@@ -9,6 +9,13 @@
 -include("zotonic.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
+%% Total request timeout
+-define(HTTPC_TIMEOUT, 20000).
+
+%% Connect timeout, server has to respond before this
+-define(HTTPC_TIMEOUT_CONNECT, 10000).
+
+
 -record(import, {endpoint = undefined,
                  context = undefined,
                  resumption_token = undefined,
@@ -23,7 +30,8 @@
 import_file(File, Context) ->
     {Root, []} = xmerl_scan:file(File, [{space, normalize}]),
     Records = parse_records(Root),
-    [z_notifier:notify({oai_pmh_import, R}, Context) || R <- Records].
+    lists:foreach(fun(R) -> z_notifier:notify_sync({oai_pmh_import, R}, Context) end,
+                  Records).
 
 %% @doc Send a notification for each record retrieved from an OAI-PMH endpoint
 import(Endpoint, Context) ->
@@ -50,18 +58,25 @@ import(#import{records = []} = Args) ->
                                        Args#import.resumption_token),
     import(Args#import{records = Records, resumption_token = NewToken});
 import(#import{} = Args) ->
-    lists:foreach(fun(R) -> z_notifier:notify({oai_pmh_import, R}, Args#import.context) end,
+    lists:foreach(fun(R) -> z_notifier:notify_sync({oai_pmh_import, R}, Args#import.context) end,
                   Args#import.records),
     import(Args#import{records = []}).
 
 
 %% @doc Execute ListRecords call on endpoint
 list_records(Endpoint, UrlParams) ->
-    Response = request(Endpoint, [{verb, "ListRecords"}] ++ UrlParams),
-    {XmlRoot, _} = xmerl_scan:string(Response, [{space, normalize}]),
-    %% Retrieve resumption token
-    ResumptionToken = ginger_xml:get_value("//resumptionToken", XmlRoot),
-    {parse_records(XmlRoot), ResumptionToken}.
+    case request(Endpoint, [{verb, "ListRecords"}] ++ UrlParams) of
+        {ok, Response} ->
+            {XmlRoot, _} = xmerl_scan:string(Response, [{space, normalize}]),
+            %% Retrieve resumption token
+            ResumptionToken = ginger_xml:get_value("//resumptionToken", XmlRoot),
+            Records = parse_records(XmlRoot),
+            lager:info("OAI-PMH fetch from ~s returned ~p records", [ Endpoint, length(Records) ]),
+            {Records, ResumptionToken};
+        _Other ->
+            % Error was logged before
+            {[], undefined}
+    end.
 
 %% @doc Execute resume request
 list_records(Endpoint, UrlParams, ResumptionToken) ->
@@ -74,14 +89,20 @@ list_records(Endpoint, UrlParams, ResumptionToken) ->
 %% @doc Execute request to OAI-PMH endpoint
 request(Endpoint, UrlParams) ->
     Url = http_utils:urlencode(Endpoint, UrlParams),
-    case httpc:request(Url) of
-        {ok, {
-            {_HTTP, 200, _OK},
-            _Headers,
-            Body
-        }} ->
-            Body;
+    HttpOptions = [
+        {relaxed, true},
+        {timeout, ?HTTPC_TIMEOUT},
+        {connect_timeout, ?HTTPC_TIMEOUT_CONNECT}
+    ],
+    Options = [
+        {body_format, string}
+    ],
+    case httpc:request(get, {Url, []}, HttpOptions, Options) of
+        {ok, {{_HTTP, 200, _OK}, _Headers, Body }} ->
+            lager:info("OAI-PMH fetch from ~s was ok", [ Url ]),
+            {ok, Body};
         Response ->
+            lager:error("OAI-PMH fetch from ~s returned ~p", [ Url, Response ]),
             Response
     end.
 


### PR DESCRIPTION
The _sync_ notification prevents spinning up a process per record, ending up with N parallel processes for N records.

Also add some logging and http request options to prevent infinite timeouts.